### PR TITLE
Add comma between street and city when creating Google Maps URL

### DIFF
--- a/src/components/Address.jsx
+++ b/src/components/Address.jsx
@@ -4,7 +4,7 @@ const Address = ({ address: street, city, zip }) => {
   const cityStateZip = `${city}, Maryland, ${zip}`;
   return (
     <a
-      href={`https://www.google.com/maps/search/?api=1&query=${street} ${cityStateZip}`}
+      href={`https://www.google.com/maps/search/?api=1&query=${street}, ${cityStateZip}`}
     >
       {street}
       <br />


### PR DESCRIPTION
Add comma between street and city when creating Google Maps URL formore accurate address parsing