### PR TITLE
update recordsperpage to 10

### DIFF
--- a/src/Filters.js
+++ b/src/Filters.js
@@ -151,7 +151,7 @@ const communityFilter = {
 
 const recordsPerPage = {
   targetApiField: "recordsperpage",
-  value: 1000,
+  value: 10,
 };
 
 export default [amenityFilter, communityFilter, recordsPerPage];


### PR DESCRIPTION
update recordsperpage to 10 in coordination with update to StructuredContent API that no longer requires all records to be pulled at once